### PR TITLE
Add learning plan sharing feature backend

### DIFF
--- a/backend/src/main/java/com/example/pafbackend/controllers/SkillPlanController.java
+++ b/backend/src/main/java/com/example/pafbackend/controllers/SkillPlanController.java
@@ -1,0 +1,71 @@
+package com.example.pafbackend.controllers;
+
+import com.example.pafbackend.models.SkillPlan;
+import com.example.pafbackend.repositories.SkillPlanRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/skillPlans")
+public class SkillPlanController {
+
+    private final SkillPlanRepository skillPlanRepository;
+
+    @Autowired
+    public SkillPlanController(SkillPlanRepository skillPlanRepository) {
+        this.skillPlanRepository = skillPlanRepository;
+    }
+
+    // Get all skill plans for current user only
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<SkillPlan>> getSkillPlansByUserId(@PathVariable String userId) {
+        List<SkillPlan> skillPlans = skillPlanRepository.findByUserId(userId);
+        return new ResponseEntity<>(skillPlans, HttpStatus.OK);
+    }
+
+    // Create new skill plan (userId comes from frontend or token logic)
+    @PostMapping
+    public ResponseEntity<SkillPlan> createSkillPlan(@RequestBody SkillPlan skillPlan) {
+        SkillPlan savedSkillPlan = skillPlanRepository.save(skillPlan);
+        return new ResponseEntity<>(savedSkillPlan, HttpStatus.CREATED);
+    }
+
+    // Update only if owner matches
+    @PutMapping("/{skillPlanId}/{userId}")
+    public ResponseEntity<SkillPlan> updateSkillPlan(@PathVariable String skillPlanId, @PathVariable String userId, @RequestBody SkillPlan updatedSkillPlan) {
+        Optional<SkillPlan> optionalSkillPlan = skillPlanRepository.findById(skillPlanId);
+        if (optionalSkillPlan.isPresent()) {
+            SkillPlan existingSkillPlan = optionalSkillPlan.get();
+            if (!existingSkillPlan.getUserId().equals(userId)) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            }
+            updatedSkillPlan.setId(skillPlanId);
+            updatedSkillPlan.setUserId(userId); // Ensure owner doesn't change
+            SkillPlan savedSkillPlan = skillPlanRepository.save(updatedSkillPlan);
+            return new ResponseEntity<>(savedSkillPlan, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    // Delete only if owner matches
+    @DeleteMapping("/{skillPlanId}/{userId}")
+    public ResponseEntity<Void> deleteSkillPlan(@PathVariable String skillPlanId, @PathVariable String userId) {
+        Optional<SkillPlan> optionalSkillPlan = skillPlanRepository.findById(skillPlanId);
+        if (optionalSkillPlan.isPresent()) {
+            SkillPlan skillPlan = optionalSkillPlan.get();
+            if (!skillPlan.getUserId().equals(userId)) {
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            }
+            skillPlanRepository.deleteById(skillPlanId);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/pafbackend/models/SkillPlan.java
+++ b/backend/src/main/java/com/example/pafbackend/models/SkillPlan.java
@@ -1,0 +1,21 @@
+package com.example.pafbackend.models;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "skillPlans")
+@Getter
+@Setter
+public class SkillPlan {
+    @Id
+    private String id;
+
+    private String userId; // Owner of the skill plan
+    private String skillDetails;
+    private String skillLevel;
+    private String resources;
+    private String date;
+    private boolean isFinished;
+}

--- a/backend/src/main/java/com/example/pafbackend/repositories/SkillPlanRepository.java
+++ b/backend/src/main/java/com/example/pafbackend/repositories/SkillPlanRepository.java
@@ -1,0 +1,12 @@
+package com.example.pafbackend.repositories;
+
+import com.example.pafbackend.models.SkillPlan;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SkillPlanRepository extends MongoRepository<SkillPlan, String> {
+    List<SkillPlan> findByUserId(String userId);
+}


### PR DESCRIPTION
This pull request introduces the backend functionality for the Learning Plan Sharing feature. The implementation includes:

 SkillPlan Model: Created core backend structure to support learning plan data models and business logic.
 SkillPlan Controller: Added controller to handle API requests for creating, retrieving, and managing learning plans. 
 SkillPlan Repository: Implemented repository to interact with the database and persist learning plan data. 